### PR TITLE
fix limescripts for mavericks

### DIFF
--- a/limescripts.js
+++ b/limescripts.js
@@ -134,7 +134,7 @@
 
   // triggers all the events
   function triggerEvents (line) {
-    var type = line.getAttribute('type');
+    var type = line.getAttribute('_type');
 
     // line event
     trigger('line', line, [line]);


### PR DESCRIPTION
limechat for mavericks changed the attribute from 'type' to '_type'
